### PR TITLE
feat: 전체 레이아웃 설정

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,17 +1,16 @@
 import Footer from "@/components/Footer";
 import Header from "@/components/Header";
+import { Slot } from "expo-router";
 import { View } from "react-native";
 
-export default function TabsLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function TabsLayout() {
   return (
     <View className="flex-1">
       <Header />
 
-      <View className="flex-1">{children}</View>
+      <View className="flex-1">
+        <Slot /> {/* 현재 페이지 */}
+      </View>
 
       <Footer />
     </View>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -12,7 +12,7 @@ export default function RootLayout() {
   return (
     <SafeAreaProvider>
       <View style={{ flex: 1, paddingBottom: insets.bottom }}>
-        <Stack />
+        <Stack screenOptions={{ headerShown: false }} />
       </View>
     </SafeAreaProvider>
   );


### PR DESCRIPTION
## 작업 내용
 - 전체 레이아웃 설정 (헤더, 메인, 푸터)
 - 탭으로 현재 페이지 랜더링

## 스크린샷
<img width="360" height="740" alt="screencapture-localhost-8081-2025-09-19-00_10_00" src="https://github.com/user-attachments/assets/b7717362-adf8-4330-90b7-c20045688754" />
